### PR TITLE
fix variable reference in marketplace availability step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -240,7 +240,7 @@ runs:
             echo "| PR Link               | ${{ steps.pr-details.outputs.PR_URL }} |"
           fi
 
-          if [ -z "${{ steps.marketplace-available.outputs.MARKETPLACE_COMMAND_EXIT_CODE }}" ] || [ "${{ steps.update-marketplace.outputs.MARKETPLACE_UPDATE_EXIT_CODE }}" -ne 0 ]; then
+          if [ -z "${{ steps.marketplace-available.outputs.MARKETPLACE_COMMAND_EXIT_CODE }}" ] || [ "${{ steps.marketplace-available.outputs.MARKETPLACE_COMMAND_EXIT_CODE }}" -ne 0 ]; then
             echo "| Made available in marketplace | ❌ |"
           else 
             echo "| Made available in marketplace | ✅ |"


### PR DESCRIPTION
This fixes a bug related to referencing the output of a previous step. This doesn't affect the action in terms of calling prism, but it results in a false positive in the summary when reporting whether the integration version was made available in the marketplace. 