### PR TITLE
use correct version tag in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To use this action in your workflow, add the following step configuration to you
 
 ```yaml
   - name: <STEP NAME>
-    uses: prismatic-io/integration-publisher@v1
+    uses: prismatic-io/integration-publisher@v1.0
     with:
       PATH_TO_YML: <PATH_TO_YML>
       PRISMATIC_URL: ${{ vars.PRISMATIC_URL }}


### PR DESCRIPTION
This updates the example in the readme to use the full `v1.0` version tag for correct usage of the action.