### PR TITLE
rename reference to OVERVIEW input; add to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This GitHub Action publishes an integration via Prismatic's Prism CLI.
 - **SKIP_COMMIT_URL_PUBLISH** (optional): Skip inclusion of commit URL in metadata. Default is `false`.
 - **SKIP_REPO_URL_PUBLISH** (optional): Skip inclusion of repository URL in metadata. Default is `false`.
 - **SKIP_PULL_REQUEST_URL_PUBLISH** (optional): Skip inclusion of pull request URL in metadata. Default is `false`.
+- **OVERVIEW** (optional): Overview to describe the purpose of the integration.
 
 ## Example Usage
 

--- a/action.yml
+++ b/action.yml
@@ -222,7 +222,7 @@ runs:
         set +e
         source $GITHUB_WORKSPACE/logger.sh
         log $INFO "Updating the marketplace version..."
-        prism integrations:marketplace "${{ steps.publish-integration.outputs.PUBLISHED_INTEGRATION_VERSION_ID }}" --available --overview=${{ inputs.MARKETPLACE_OVERVIEW }}
+        prism integrations:marketplace "${{ steps.publish-integration.outputs.PUBLISHED_INTEGRATION_VERSION_ID }}" --available --overview="${{ inputs.OVERVIEW }}"
         EXIT_CODE=$?
         echo "MARKETPLACE_COMMAND_EXIT_CODE=$EXIT_CODE" >> $GITHUB_OUTPUT
       env:


### PR DESCRIPTION
This fixes a misnamed reference that results in the action's OVERVIEW input not being published properly. 