### PR TITLE
add cni publish support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,21 @@ or
 
 Optional inputs can be passed via the `with` block as desired.
 
+### Additional Workflow Steps - CNI only
+
+The following steps are an example of preparing the CNI bundle prior to publishing via this action. The `working-directory` will likely match the `PATH_TO_CNI` input passed to the integration-publisher action.
+```yaml
+  - uses: actions/checkout@v4
+
+  - name: Install dependencies
+    run: npm install
+    working-directory: src/my-cni
+
+  - name: Build integration bundle
+    run: npm run build
+    working-directory: src/my-cni
+```
+
 ## Acquiring PRISM_REFRESH_TOKEN
 
 To acquire a refresh token that will authenticate against the Prism CLI, run this command in a terminal (assuming you are authenticated with the CLI):

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This GitHub Action publishes an integration via Prismatic's Prism CLI.
 
 - **PRISMATIC_URL** (required): The target Prismatic API to publish to.
 - **PRISM_REFRESH_TOKEN** (required): The token granting access to the API at the PRISMATIC_URL provided.
-- **PATH_TO_YML** (required): The path to the integration yml file that is to be published.
+- **PATH_TO_CNI** (optional): The path to the Code Native Integration source code, usually the same location as the CNI's package.json. If not provided, the root will be used.
+- **PATH_TO_YML** (optional): The path to the integration yml file that is to be published.
 - **INTEGRATION_ID** (required): The ID of the integration to be published. Corresponds to the Prismatic environment defined by the PRISMATIC_URL.
 - **SKIP_COMMIT_HASH_PUBLISH** (optional): Skip inclusion of commit hash in metadata. Default is `false`.
 - **SKIP_COMMIT_URL_PUBLISH** (optional): Skip inclusion of commit URL in metadata. Default is `false`.
@@ -14,6 +15,10 @@ This GitHub Action publishes an integration via Prismatic's Prism CLI.
 - **SKIP_PULL_REQUEST_URL_PUBLISH** (optional): Skip inclusion of pull request URL in metadata. Default is `false`.
 - **OVERVIEW** (optional): Overview to describe the purpose of the integration (used in conjunction with <u>MAKE_AVAILABLE_IN_MARKETPLACE</u>).
 - **MAKE_AVAILABLE_IN_MARKETPLACE** (optional): Make version available in the marketplace.
+
+## PATH_TO_CNI vs PATH_TO_YML
+
+Use `PATH_TO_CNI` if publishing a Code Native Integration. Use `PATH_TO_YML` if publishing an integration defined in a YML file only. In the unlikely scenario that both are provided, `PATH_TO_YML` will take precedence. 
 
 ## Example Usage
 
@@ -24,6 +29,18 @@ To use this action in your workflow, add the following step configuration to you
   uses: prismatic-io/integration-publisher@v1.0
   with:
     PATH_TO_YML: <PATH_TO_YML>
+    PRISMATIC_URL: ${{ vars.PRISMATIC_URL }}
+    PRISM_REFRESH_TOKEN: ${{ secrets.PRISM_REFRESH_TOKEN }}
+    INTEGRATION_ID: <INTEGRATION_ID>
+```
+
+or
+
+```yaml
+- name: <STEP NAME>
+  uses: prismatic-io/integration-publisher@v1.0
+  with:
+    PATH_TO_CNI: <PATH_TO_CNI>
     PRISMATIC_URL: ${{ vars.PRISMATIC_URL }}
     PRISM_REFRESH_TOKEN: ${{ secrets.PRISM_REFRESH_TOKEN }}
     INTEGRATION_ID: <INTEGRATION_ID>

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This GitHub Action publishes an integration via Prismatic's Prism CLI.
 
 ## PATH_TO_CNI vs PATH_TO_YML
 
-Use `PATH_TO_CNI` if publishing a Code Native Integration. Use `PATH_TO_YML` if publishing an integration defined in a YML file only. In the unlikely scenario that both are provided, `PATH_TO_YML` will take precedence. 
+Use `PATH_TO_CNI` if publishing a Code Native Integration. Use `PATH_TO_YML` if publishing an integration defined in a YML file only. In the unlikely scenario that both are provided, an error will be thrown. 
 
 ## Example Usage
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To use this action in your workflow, add the following step configuration to you
 
 ```yaml
 - name: <STEP NAME>
-  uses: prismatic-io/integration-publisher@v1.0
+  uses: prismatic-io/integration-publisher@<LATEST_VERSION>
   with:
     PATH_TO_YML: <PATH_TO_YML>
     PRISMATIC_URL: ${{ vars.PRISMATIC_URL }}
@@ -38,7 +38,7 @@ or
 
 ```yaml
 - name: <STEP NAME>
-  uses: prismatic-io/integration-publisher@v1.0
+  uses: prismatic-io/integration-publisher@<LATEST_VERSION>
   with:
     PATH_TO_CNI: <PATH_TO_CNI>
     PRISMATIC_URL: ${{ vars.PRISMATIC_URL }}

--- a/action.yml
+++ b/action.yml
@@ -134,7 +134,7 @@ runs:
           log $INFO "INTEGRATION_ID: ${{ inputs.INTEGRATION_ID }}"
         fi
 
-    - name: Check if PATH_TO_YML is set
+    - name: Check if PATH_TO_YML or PATH_TO_CNI is set
       shell: bash
       run: |
         source $GITHUB_WORKSPACE/logger.sh

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,10 @@ inputs:
     required: true
   PATH_TO_YML:
     description: "Path to the YAML file containing the integration configuration."
-    required: true
+    required: false
+  PATH_TO_CNI:
+    description: "The path to the Code Native Integration source code, usually the same location as the CNI's package.json. If not provided, the root will be used."
+    required: false
   PRISMATIC_URL:
     description: "The target Prismatic API to import to."
     required: true
@@ -135,11 +138,12 @@ runs:
       shell: bash
       run: |
         source $GITHUB_WORKSPACE/logger.sh
-        if [ -z "${{ inputs.PATH_TO_YML }}" ]; then
-          log $ERROR "PATH_TO_YML is not set"
+        if [ -z "${{ inputs.PATH_TO_YML }}" ] && [ -z "${{ inputs.PATH_TO_CNI }}" ]; then
+          log $ERROR "Neither PATH_TO_YML nor PATH_TO_CNI is set"
           exit 1
         else
-          log $INFO "PATH_TO_YML: ${{ inputs.PATH_TO_YML }}"
+          [ -n "$PATH_TO_YML" ] && log $INFO "PATH_TO_YML: $PATH_TO_YML"
+          [ -n "$PATH_TO_CNI" ] && log $INFO "Publishing CNI. PATH_TO_CNI: $PATH_TO_CNI"
         fi
 
     - name: Print logo to console once
@@ -177,7 +181,15 @@ runs:
     - name: Import Integration
       shell: bash
       run: |
-        prism integrations:import -i="${{ inputs.INTEGRATION_ID }}" -p="${{ inputs.PATH_TO_YML }}"
+        if [ -n "${{ inputs.PATH_TO_YML }}" ]; then
+          prism integrations:import -i="${{ inputs.INTEGRATION_ID }}" -p="${{ inputs.PATH_TO_YML }}"
+        elif [ -n "${{ inputs.PATH_TO_CNI }}" ]; then
+          cd "${{ inputs.PATH_TO_CNI }}"
+          prism integrations:import -i="${{ inputs.INTEGRATION_ID }}"
+        else
+          echo "Neither PATH_TO_YML nor PATH_TO_CNI is set"
+          exit 1
+        fi
       env:
         PRISMATIC_URL: ${{ inputs.PRISMATIC_URL }}
         PRISM_REFRESH_TOKEN: ${{ inputs.PRISM_REFRESH_TOKEN }}
@@ -186,6 +198,18 @@ runs:
       id: publish-integration
       shell: bash
       run: |
+        CURRENT_DIR=$(realpath "$PWD")
+
+        if [ -n "${{ inputs.PATH_TO_CNI }}" ]; then
+          TARGET_DIR=$(realpath "${{ inputs.PATH_TO_CNI }}")
+        else
+          TARGET_DIR="$CURRENT_DIR"
+        fi
+
+        if [ "$CURRENT_DIR" != "$TARGET_DIR" ]; then
+          cd "$TARGET_DIR"
+        fi
+
         COMMAND="prism integrations:publish \"${{ inputs.INTEGRATION_ID }}\""
 
         if [ "${{ inputs.SKIP_COMMIT_HASH_PUBLISH }}" = "false" ]; then

--- a/action.yml
+++ b/action.yml
@@ -141,9 +141,12 @@ runs:
         if [ -z "${{ inputs.PATH_TO_YML }}" ] && [ -z "${{ inputs.PATH_TO_CNI }}" ]; then
           log $ERROR "Neither PATH_TO_YML nor PATH_TO_CNI is set"
           exit 1
+        elif [ -n "${{ inputs.PATH_TO_CNI }}" ] && [ -n "${{ inputs.PATH_TO_YML }}" ]; then
+          log $ERROR "Both PATH_TO_YML and PATH_TO_CNI have been provided. Please provide only one of these inputs."
+          exit 1
         else
-          [ -n "$PATH_TO_YML" ] && log $INFO "PATH_TO_YML: $PATH_TO_YML"
-          [ -n "$PATH_TO_CNI" ] && log $INFO "Publishing CNI. PATH_TO_CNI: $PATH_TO_CNI"
+          [ -n "${{ inputs.PATH_TO_YML }}" ] && log $INFO "PATH_TO_YML: $PATH_TO_YML"
+          [ -n "${{ inputs.PATH_TO_CNI }}" ] && log $INFO "Publishing CNI. PATH_TO_CNI: $PATH_TO_CNI"
         fi
 
     - name: Print logo to console once


### PR DESCRIPTION
This adds support for publishing a Code Native Integration. A new input, `PATH_TO_CNI`, has been added. Either `PATH_TO_YML` or `PATH_TO_CNI` must be provided, but provision of both is disallowed due to ambiguity around user intent when both are present. When `PATH_TO_CNI` is provided, the working directory is changed accordingly. This allows multiple `CNI`s to publish in a given workflow. An additional example has also been added to the READme.