### PR TITLE
Log paths correctly

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -144,9 +144,10 @@ runs:
         elif [ -n "${{ inputs.PATH_TO_CNI }}" ] && [ -n "${{ inputs.PATH_TO_YML }}" ]; then
           log $ERROR "Both PATH_TO_YML and PATH_TO_CNI have been provided. Please provide only one of these inputs."
           exit 1
-        else
-          [ -n "${{ inputs.PATH_TO_YML }}" ] && log $INFO "PATH_TO_YML: $PATH_TO_YML"
-          [ -n "${{ inputs.PATH_TO_CNI }}" ] && log $INFO "Publishing CNI. PATH_TO_CNI: $PATH_TO_CNI"
+        elif [ -n "${{ inputs.PATH_TO_YML }}" ]; then
+          log $INFO "PATH_TO_YML: ${{ inputs.PATH_TO_YML }}"
+        elif [ -n "${{ inputs.PATH_TO_CNI }}" ]; then
+          log $INFO "Publishing code-native integration. PATH_TO_CNI: ${{ inputs.PATH_TO_CNI }}"
         fi
 
     - name: Print logo to console once


### PR DESCRIPTION
This change does a couple of things:
- Swaps `$PATH_TO_YML` and `$PATH_TO_CNI` to `${{ inputs.PATH_TO_YML }}` and `${{ inputs.PATH_TO_CNI }}` respectively, so CNI or YAML paths are actually logged out
- Fixes a regression in publishing YAML-defined integrations. On v1.3, if you supply a `PATH_TO_YAML`, the `[ -n "${{ inputs.PATH_TO_CNI }}" ] && log $INFO "Publishing CNI. PATH_TO_CNI: $PATH_TO_CNI"` line returns an error code of `1` because `[ -n ""]` returns `1`. The step, then, fails, and the YAML integration is not published. This refactors the log lines to be within `if` blocks.