### PR TITLE
Bump node, prism, add PRISM_VERSION param

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,10 @@ inputs:
     description: "Overview to describe the purpose of the integration."
     required: false
     default: ""
+  PRISM_VERSION:
+    description: "The version of the Prism CLI to install. Defaults to ^9."
+    required: false
+    default: "^9"
 
 runs:
   using: "composite"
@@ -103,7 +107,7 @@ runs:
     - name: Set up Node using Github Action
       uses: actions/setup-node@v4
       with:
-        node-version: "18.19.1"
+        node-version: "22"
 
     # Check for existence of required inputs.
     - name: Check if PRISMATIC_URL is set
@@ -180,7 +184,7 @@ runs:
         source $GITHUB_WORKSPACE/logger.sh
         if ! npm list -g @prismatic-io/prism &> /dev/null; then
           log $INFO "\U1F527 Prism CLI is not installed. Installing..."
-          npm install --global @prismatic-io/prism@^8.2.0
+          npm install --global @prismatic-io/prism@${{ inputs.PRISM_VERSION }}
         else
           log $INFO "Prism CLI is already installed."
         fi


### PR DESCRIPTION
This should address some compatibility issues with this action as well as allow users to specify a version of prism.

This will be released as v2.0.