### PR TITLE
Add --comment flag to publish integration command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,10 @@ inputs:
     description: "Overview to describe the purpose of the integration."
     required: false
     default: ""
+  COMMENT:
+    description: "A comment to include with the published version."
+    required: false
+    default: ""
   PRISM_VERSION:
     description: "The version of the Prism CLI to install. Defaults to ^9."
     required: false
@@ -242,6 +246,10 @@ runs:
 
         if [ -n "${{ inputs.CUSTOMER_ID }}" ]; then
           COMMAND="$COMMAND --customer=${{ inputs.CUSTOMER_ID }}"
+        fi
+
+        if [ -n "${{ inputs.COMMENT }}" ]; then
+          COMMAND="$COMMAND --comment=\"${{ inputs.COMMENT }}\""
         fi
 
         OUTPUT=$($COMMAND)


### PR DESCRIPTION
## Summary
- Adds a `COMMENT` input to the action that, when provided, appends `--comment` to the `prism integrations:publish` command
- Follows the same pattern as the existing optional flags (e.g., `CUSTOMER_ID`)

## Test plan
- [ ] Verify the action works without `COMMENT` input (no change in behavior)
- [ ] Verify the action appends `--comment="<value>"` when `COMMENT` is provided