### PR TITLE
Add per-flow test API keys support and include CI workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,41 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: jdx/mise-action@v4
+      - name: Run lint + bats
+        run: mise run test
+
+  action-smoke:
+    # End-to-end exercise of the composite action against stubbed `prism` and
+    # `npm`. Catches wiring bugs in action.yml (env passthrough, action_path,
+    # input names) that the bats tests don't see because they hit the script
+    # directly.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install stub prism on PATH
+        run: tests/install-stubs.sh
+      - name: Run the composite action
+        uses: ./
+        with:
+          INTEGRATION_ID: smoke_int
+          PATH_TO_YML: tests/fixtures/integration.yml
+          PRISMATIC_URL: https://example.invalid
+          PRISM_REFRESH_TOKEN: fake-refresh-token
+          TEST_API_KEYS: |
+            flowA: keyA
+            flowB: keyB with spaces
+            Customer Webhook: keyC
+      - name: Assert prism received the expected import argv
+        run: tests/assert-prism-import.sh

--- a/DEV.md
+++ b/DEV.md
@@ -1,0 +1,8 @@
+# Development
+
+Tool versions are pinned in `mise.toml`.
+
+```sh
+mise install
+mise run test     # lint + bats (matches CI)
+```

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This GitHub Action publishes an integration via Prismatic's Prism CLI.
 - **SKIP_PULL_REQUEST_URL_PUBLISH** (optional): Skip inclusion of pull request URL in metadata. Default is `false`.
 - **OVERVIEW** (optional): Overview to describe the purpose of the integration (used in conjunction with <u>MAKE_AVAILABLE_IN_MARKETPLACE</u>).
 - **MAKE_AVAILABLE_IN_MARKETPLACE** (optional): Make version available in the marketplace.
+- **TEST_API_KEYS** (optional): Test API keys to associate with flows for test executions. A YAML mapping of `flowName: API_KEY`, passed as a `|` block scalar — see [Providing test API keys](#providing-test-api-keys) for the pattern and the rationale for `|`. Pass via secrets — do not hard-code.
 
 ## PATH_TO_CNI vs PATH_TO_YML
 
@@ -80,6 +81,27 @@ To check which API Prism is currently configured for, and to fetch your tenant I
 ```
 prism me
 ```
+
+## Providing test API keys
+
+`TEST_API_KEYS` lets a CI run import an integration with per-flow API keys for test executions. Pass a YAML mapping inside a `|` block scalar — flow name on the left, API key on the right. The action handles prism's required quoting internally.
+
+```yaml
+- uses: prismatic-io/integration-publisher@<LATEST_VERSION>
+  with:
+    PATH_TO_CNI: <PATH_TO_CNI>
+    PRISMATIC_URL: ${{ vars.PRISMATIC_URL }}
+    PRISM_REFRESH_TOKEN: ${{ secrets.PRISM_REFRESH_TOKEN }}
+    INTEGRATION_ID: <INTEGRATION_ID>
+    TEST_API_KEYS: |
+      orderSync: ${{ secrets.ORDER_SYNC_TEST_KEY }}
+      inventoryPoll: ${{ secrets.INVENTORY_POLL_TEST_KEY }}
+      Customer Webhook: ${{ secrets.CUSTOMER_WEBHOOK_TEST_KEY }}
+```
+
+> **Note:** while this looks like a map, GitHub Actions limitations mean it's actually a string — keep the leading `|` so YAML treats it as one. Without it the workflow fails with `A mapping was not expected`.
+
+Values are passed to the action via an environment variable (not interpolated into a shell command), so secrets containing shell metacharacters are safe. The only restriction is that flow names and keys may not contain literal `"` characters (a prism parser limitation).
 
 ## What is Prismatic?
 

--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,17 @@ inputs:
     description: "The version of the Prism CLI to install. Defaults to ^9."
     required: false
     default: "^9"
+  TEST_API_KEYS:
+    description: |
+      Test API keys to associate with flows for test executions. A YAML
+      mapping of flow name to API key, passed as a `|` block scalar
+      (GitHub Actions inputs are string-typed; the `|` delivers the map
+      as a literal multi-line string for the action to parse). See README
+      for the full pattern. Flow names with spaces are supported.
+      Neither side may contain a literal `"`. Pass via secrets — do not
+      hard-code.
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -109,7 +120,7 @@ runs:
     # Node may be installed in the parent workflow. This ensures the version is what Prism expects.
     # This action will use a cached version if available.
     - name: Set up Node using Github Action
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: "22"
 
@@ -186,7 +197,7 @@ runs:
       shell: bash
       run: |
         source $GITHUB_WORKSPACE/logger.sh
-        if ! npm list -g @prismatic-io/prism &> /dev/null; then
+        if ! command -v prism &> /dev/null; then
           log $INFO "\U1F527 Prism CLI is not installed. Installing..."
           npm install --global @prismatic-io/prism@${{ inputs.PRISM_VERSION }}
         else
@@ -195,20 +206,15 @@ runs:
 
     - name: Import Integration
       shell: bash
-      run: |
-        if [ -n "${{ inputs.PATH_TO_YML }}" ]; then
-          prism integrations:import -i="${{ inputs.INTEGRATION_ID }}" -p="${{ inputs.PATH_TO_YML }}"
-        elif [ -n "${{ inputs.PATH_TO_CNI }}" ]; then
-          cd "${{ inputs.PATH_TO_CNI }}"
-          prism integrations:import -i="${{ inputs.INTEGRATION_ID }}"
-        else
-          echo "Neither PATH_TO_YML nor PATH_TO_CNI is set"
-          exit 1
-        fi
+      run: ${{ github.action_path }}/scripts/import.sh
       env:
         PRISMATIC_URL: ${{ inputs.PRISMATIC_URL }}
         PRISM_REFRESH_TOKEN: ${{ inputs.PRISM_REFRESH_TOKEN }}
         PRISMATIC_TENANT_ID: ${{ inputs.PRISMATIC_TENANT_ID }}
+        INTEGRATION_ID: ${{ inputs.INTEGRATION_ID }}
+        PATH_TO_YML: ${{ inputs.PATH_TO_YML }}
+        PATH_TO_CNI: ${{ inputs.PATH_TO_CNI }}
+        TEST_API_KEYS: ${{ inputs.TEST_API_KEYS }}
 
     - name: Publish Integration
       id: publish-integration

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,17 @@
+[tools]
+bats = "1.13.0"
+shellcheck = "0.11.0"
+yq = "4.45.4"
+jq = "1.7.1"
+
+[tasks.lint]
+description = "Static-check shell scripts with shellcheck"
+run = "shellcheck scripts/*.sh tests/*.sh tests/stubs/*"
+
+[tasks.bats]
+description = "Run bats unit tests"
+run = "bats tests/"
+
+[tasks.test]
+description = "Run all checks (lint + bats)"
+depends = ["lint", "bats"]

--- a/scripts/import.sh
+++ b/scripts/import.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Build and run `prism integrations:import` from action inputs.
+#
+# Inputs are read from environment variables — never interpolated into the
+# shell by the caller — so values containing shell metacharacters cannot
+# break out into command execution.
+#
+# Required env: INTEGRATION_ID, plus one of PATH_TO_YML or PATH_TO_CNI.
+# Optional env: TEST_API_KEYS — a YAML mapping of flowName -> API_KEY. The
+#               script wraps each pair in prism's required "name"="key"
+#               format before passing it to --test-api-key.
+# PRISM_BIN overrides the prism executable for testing.
+
+set -euo pipefail
+
+: "${INTEGRATION_ID:?INTEGRATION_ID is required}"
+
+PRISM_BIN="${PRISM_BIN:-prism}"
+PATH_TO_YML="${PATH_TO_YML:-}"
+PATH_TO_CNI="${PATH_TO_CNI:-}"
+TEST_API_KEYS="${TEST_API_KEYS:-}"
+
+args=()
+
+if [[ -n "$PATH_TO_YML" ]]; then
+  args+=("-i=$INTEGRATION_ID" "-p=$PATH_TO_YML")
+elif [[ -n "$PATH_TO_CNI" ]]; then
+  cd "$PATH_TO_CNI"
+  args+=("-i=$INTEGRATION_ID")
+else
+  echo "Neither PATH_TO_YML nor PATH_TO_CNI is set" >&2
+  exit 1
+fi
+
+if [[ -n "${TEST_API_KEYS//[[:space:]]/}" ]]; then
+  for tool in yq jq; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+      echo "TEST_API_KEYS requires '$tool' on PATH (preinstalled on GitHub-hosted runners)." >&2
+      exit 1
+    fi
+  done
+
+  if ! TEST_API_KEYS_JSON=$(yq -o=json '.' <<<"$TEST_API_KEYS" 2>/dev/null); then
+    echo "TEST_API_KEYS is not valid YAML." >&2
+    exit 1
+  fi
+
+  kind=$(jq -r 'type' <<<"$TEST_API_KEYS_JSON")
+  if [[ "$kind" != "object" ]]; then
+    echo "TEST_API_KEYS must be a YAML mapping (flowName: apiKey), got $kind." >&2
+    exit 1
+  fi
+
+  while IFS= read -r entry; do
+    flow_name=$(jq -r '.key   | if . == null then "" else tostring end' <<<"$entry")
+    api_key=$(jq   -r '.value | if . == null then "" else tostring end' <<<"$entry")
+
+    if [[ -z "$flow_name" ]]; then
+      echo "TEST_API_KEYS contains an entry with an empty flow name." >&2
+      exit 1
+    fi
+    if [[ -z "$api_key" ]]; then
+      echo "TEST_API_KEYS: empty API key for flow '$flow_name'." >&2
+      exit 1
+    fi
+    # prism's --test-api-key parser uses [^"] for both flow name and value,
+    # so neither side can contain a literal double-quote.
+    if [[ "$flow_name" == *\"* || "$api_key" == *\"* ]]; then
+      echo "TEST_API_KEYS: flow name and API key must not contain a literal '\"' (flow: '$flow_name')." >&2
+      exit 1
+    fi
+
+    args+=("--test-api-key=\"${flow_name}\"=\"${api_key}\"")
+  done < <(jq -c 'to_entries[]' <<<"$TEST_API_KEYS_JSON")
+fi
+
+exec "$PRISM_BIN" integrations:import "${args[@]}"

--- a/tests/assert-prism-import.sh
+++ b/tests/assert-prism-import.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Assert the stub prism captured an integrations:import call with the
+# expected argv. Used by the action-smoke CI job to validate both the
+# block-scalar and nested-object forms of TEST_API_KEYS.
+
+set -euo pipefail
+shopt -s nullglob
+
+calls=("$RUNNER_TEMP"/prism-calls/*)
+if [[ ${#calls[@]} -eq 0 ]]; then
+  echo "::error::stub prism was not invoked"
+  exit 1
+fi
+
+import_call=""
+for f in "${calls[@]}"; do
+  argv="$(tr '\0' '\n' < "$f")"
+  if grep -qx 'integrations:import' <<<"$argv"; then
+    import_call="$f"
+    break
+  fi
+done
+
+if [[ -z "$import_call" ]]; then
+  echo "::error::no integrations:import call captured"
+  for f in "${calls[@]}"; do
+    echo "--- $f"
+    tr '\0' '\n' < "$f"
+  done
+  exit 1
+fi
+
+argv="$(tr '\0' '\n' < "$import_call")"
+echo "captured import argv:"
+echo "$argv"
+
+grep -qx -- '-i=smoke_int' <<<"$argv"
+grep -qx -- '-p=tests/fixtures/integration.yml' <<<"$argv"
+grep -qx -- '--test-api-key="flowA"="keyA"' <<<"$argv"
+grep -qx -- '--test-api-key="flowB"="keyB with spaces"' <<<"$argv"
+grep -qx -- '--test-api-key="Customer Webhook"="keyC"' <<<"$argv"

--- a/tests/fixtures/integration.yml
+++ b/tests/fixtures/integration.yml
@@ -1,0 +1,1 @@
+name: smoke

--- a/tests/import.bats
+++ b/tests/import.bats
@@ -1,0 +1,209 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/import.sh.
+#
+# Each test runs the script with a stub `prism` that records its argv to a
+# file, then asserts on the captured argv. This verifies argument
+# construction without contacting a real Prismatic backend.
+
+setup() {
+  PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  WORKDIR="$(mktemp -d)"
+  ARGV_FILE="$WORKDIR/argv"
+  CWD_FILE="$WORKDIR/cwd"
+  CANARY="$WORKDIR/pwned"
+  export ARGV_FILE CWD_FILE
+
+  cat > "$WORKDIR/prism" <<'STUB'
+#!/usr/bin/env bash
+pwd > "$CWD_FILE"
+{ printf '%s\0' "$@"; } > "$ARGV_FILE"
+STUB
+  chmod +x "$WORKDIR/prism"
+  export PRISM_BIN="$WORKDIR/prism"
+}
+
+teardown() {
+  rm -rf "$WORKDIR"
+}
+
+# Read the captured argv as a newline-joined string for easy matching.
+captured_argv() {
+  tr '\0' '\n' < "$ARGV_FILE"
+}
+
+@test "PATH_TO_YML produces -i and -p flags" {
+  INTEGRATION_ID=int_1 \
+  PATH_TO_YML=foo.yml \
+    "$PROJECT_ROOT/scripts/import.sh"
+
+  run captured_argv
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"integrations:import"* ]]
+  [[ "$output" == *"-i=int_1"* ]]
+  [[ "$output" == *"-p=foo.yml"* ]]
+  [[ "$output" != *"--test-api-key"* ]]
+}
+
+@test "PATH_TO_CNI cds and produces only -i" {
+  mkdir -p "$WORKDIR/cni"
+  INTEGRATION_ID=int_2 \
+  PATH_TO_CNI="$WORKDIR/cni" \
+    "$PROJECT_ROOT/scripts/import.sh"
+
+  run captured_argv
+  [[ "$output" == *"-i=int_2"* ]]
+  [[ "$output" != *"-p="* ]]
+  grep -q "/cni\$" "$CWD_FILE"
+}
+
+@test "missing path inputs fails with explicit error" {
+  run env INTEGRATION_ID=int_3 PATH_TO_YML= PATH_TO_CNI= \
+    "$PROJECT_ROOT/scripts/import.sh"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Neither PATH_TO_YML nor PATH_TO_CNI is set"* ]]
+}
+
+@test "single test API key emits prism's quoted format" {
+  INTEGRATION_ID=int_1 \
+  PATH_TO_YML=foo.yml \
+  TEST_API_KEYS='flowA: secretA' \
+    "$PROJECT_ROOT/scripts/import.sh"
+
+  run captured_argv
+  [[ "$output" == *'--test-api-key="flowA"="secretA"'* ]]
+}
+
+@test "multiple test API keys produce multiple flags" {
+  INTEGRATION_ID=int_1 \
+  PATH_TO_YML=foo.yml \
+  TEST_API_KEYS=$'flowA: secretA\nflowB: secretB\nflowC: secretC' \
+    "$PROJECT_ROOT/scripts/import.sh"
+
+  count=$(captured_argv | grep -c '^--test-api-key=')
+  [ "$count" -eq 3 ]
+  captured_argv | grep -qx -- '--test-api-key="flowA"="secretA"'
+  captured_argv | grep -qx -- '--test-api-key="flowB"="secretB"'
+  captured_argv | grep -qx -- '--test-api-key="flowC"="secretC"'
+}
+
+@test "flow names with spaces are accepted" {
+  INTEGRATION_ID=int_1 \
+  PATH_TO_YML=foo.yml \
+  TEST_API_KEYS=$'Customer Webhook: secretA\nOrder Sync: secretB' \
+    "$PROJECT_ROOT/scripts/import.sh"
+
+  captured_argv | grep -qx -- '--test-api-key="Customer Webhook"="secretA"'
+  captured_argv | grep -qx -- '--test-api-key="Order Sync"="secretB"'
+}
+
+@test "empty TEST_API_KEYS string adds no flags" {
+  INTEGRATION_ID=int_1 \
+  PATH_TO_YML=foo.yml \
+  TEST_API_KEYS="" \
+    "$PROJECT_ROOT/scripts/import.sh"
+
+  run captured_argv
+  [[ "$output" != *"--test-api-key"* ]]
+}
+
+@test "whitespace-only TEST_API_KEYS adds no flags" {
+  INTEGRATION_ID=int_1 \
+  PATH_TO_YML=foo.yml \
+  TEST_API_KEYS=$'   \n\n   ' \
+    "$PROJECT_ROOT/scripts/import.sh"
+
+  run captured_argv
+  [[ "$output" != *"--test-api-key"* ]]
+}
+
+@test "non-mapping YAML (sequence) is rejected" {
+  run env INTEGRATION_ID=int_1 PATH_TO_YML=foo.yml \
+    PRISM_BIN="$PRISM_BIN" \
+    TEST_API_KEYS=$'- flowA\n- flowB' \
+    "$PROJECT_ROOT/scripts/import.sh"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must be a YAML mapping"* ]]
+  [ ! -f "$ARGV_FILE" ]
+}
+
+@test "non-mapping YAML (scalar) is rejected" {
+  run env INTEGRATION_ID=int_1 PATH_TO_YML=foo.yml \
+    PRISM_BIN="$PRISM_BIN" \
+    TEST_API_KEYS="just a plain string" \
+    "$PROJECT_ROOT/scripts/import.sh"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must be a YAML mapping"* ]]
+}
+
+@test "literal double-quote in flow name is rejected" {
+  run env INTEGRATION_ID=int_1 PATH_TO_YML=foo.yml \
+    PRISM_BIN="$PRISM_BIN" \
+    TEST_API_KEYS='"flow\"name": secret' \
+    "$PROJECT_ROOT/scripts/import.sh"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *'must not contain a literal'* ]]
+}
+
+@test "literal double-quote in API key is rejected" {
+  run env INTEGRATION_ID=int_1 PATH_TO_YML=foo.yml \
+    PRISM_BIN="$PRISM_BIN" \
+    TEST_API_KEYS='flowA: "secret\"value"' \
+    "$PROJECT_ROOT/scripts/import.sh"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *'must not contain a literal'* ]]
+}
+
+@test "empty API key value is rejected" {
+  run env INTEGRATION_ID=int_1 PATH_TO_YML=foo.yml \
+    PRISM_BIN="$PRISM_BIN" \
+    TEST_API_KEYS='flowA:' \
+    "$PROJECT_ROOT/scripts/import.sh"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"empty API key"* ]]
+}
+
+@test "shell metacharacters in API key value do not execute" {
+  # If the script ever interpolated $TEST_API_KEYS into a command line, the
+  # `$(touch ...)` substitution would run. With env-var passthrough and an
+  # argv array, the value reaches prism inert.
+  INTEGRATION_ID=int_1 \
+  PATH_TO_YML=foo.yml \
+  TEST_API_KEYS="flowA: \$(touch $CANARY)" \
+    "$PROJECT_ROOT/scripts/import.sh"
+
+  [ ! -e "$CANARY" ]
+  run captured_argv
+  [[ "$output" == *"--test-api-key=\"flowA\"=\"\$(touch $CANARY)\""* ]]
+}
+
+@test "shell metacharacters in INTEGRATION_ID do not execute" {
+  INTEGRATION_ID="int_1\"; touch $CANARY; #" \
+  PATH_TO_YML=foo.yml \
+    "$PROJECT_ROOT/scripts/import.sh"
+
+  [ ! -e "$CANARY" ]
+  run captured_argv
+  [[ "$output" == *"-i=int_1\"; touch $CANARY; #"* ]]
+}
+
+@test "API key value containing '=' (e.g. base64) is preserved" {
+  INTEGRATION_ID=int_1 \
+  PATH_TO_YML=foo.yml \
+  TEST_API_KEYS='flowA: "YWJjZA=="' \
+    "$PROJECT_ROOT/scripts/import.sh"
+
+  captured_argv | grep -qx -- '--test-api-key="flowA"="YWJjZA=="'
+}
+
+@test "missing INTEGRATION_ID fails" {
+  run env -u INTEGRATION_ID PATH_TO_YML=foo.yml PRISM_BIN="$PRISM_BIN" \
+    "$PROJECT_ROOT/scripts/import.sh"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"INTEGRATION_ID"* ]]
+}

--- a/tests/install-stubs.sh
+++ b/tests/install-stubs.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Install action-smoke stub binaries onto $GITHUB_PATH and prepare the
+# capture directory the stubs write to.
+
+set -euo pipefail
+
+: "${RUNNER_TEMP:?RUNNER_TEMP is required (run from a GitHub Actions runner)}"
+: "${GITHUB_PATH:?GITHUB_PATH is required}"
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+stub_dir="$RUNNER_TEMP/bin"
+
+mkdir -p "$stub_dir" "$RUNNER_TEMP/prism-calls"
+install -m 0755 "$here/stubs/prism" "$stub_dir/prism"
+
+echo "$stub_dir" >> "$GITHUB_PATH"

--- a/tests/stubs/prism
+++ b/tests/stubs/prism
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Stub `prism` for action-smoke CI: captures argv to RUNNER_TEMP/prism-calls/
+# and emits a fake version ID so the publish step can parse stdout.
+out="$RUNNER_TEMP/prism-calls/$(date +%s%N)-$$"
+{ printf '%s\0' "$@"; } > "$out"
+echo "fakeIntegrationVersionId"


### PR DESCRIPTION
Unfortunately all inputs into GH Actions _must be_ strings so that makes multi-arg flags like the API keys mildly cumbersome. This change aligns with prior art GH Actions dealing with the same limitations and calls out the UX shenanigans.