### PR TITLE
Surface integration source path in publish summary

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -161,6 +161,8 @@ runs:
         VERSION_ID: ${{ steps.publish-integration.outputs.PUBLISHED_INTEGRATION_VERSION_ID }}
         PRISMATIC_URL: ${{ inputs.PRISMATIC_URL }}
         PRISMATIC_TENANT_ID: ${{ inputs.PRISMATIC_TENANT_ID }}
+        PATH_TO_YML: ${{ inputs.PATH_TO_YML }}
+        PATH_TO_CNI: ${{ inputs.PATH_TO_CNI }}
         COMMIT_URL: ${{ steps.scm.outputs.COMMIT_URL }}
         PR_URL: ${{ steps.scm.outputs.PR_URL }}
         SKIP_COMMIT_HASH_PUBLISH: ${{ inputs.SKIP_COMMIT_HASH_PUBLISH }}

--- a/scripts/summary.sh
+++ b/scripts/summary.sh
@@ -14,11 +14,19 @@ skip_row() {
   fi
 }
 
+source_label="${PATH_TO_CNI:-${PATH_TO_YML:-$INTEGRATION_ID}}"
+
 {
   echo "### Integration Published :rocket:"
+  echo "#### \`$source_label\`"
   echo "|![Prismatic Logo](https://app.prismatic.io/logo_fullcolor_white.svg)| Publish Info |"
   echo "| --------------------- | --------------- |"
   echo "| Integration ID        | $INTEGRATION_ID |"
+  if [[ -n "${PATH_TO_CNI:-}" ]]; then
+    echo "| Source Directory      | $PATH_TO_CNI |"
+  elif [[ -n "${PATH_TO_YML:-}" ]]; then
+    echo "| Source File           | $PATH_TO_YML |"
+  fi
   echo "| Published Integration Version ID | ${VERSION_ID:-} |"
   echo "| Target Stack          | $PRISMATIC_URL |"
   echo "| Designer Link         | $PRISMATIC_URL/designer/$INTEGRATION_ID |"

--- a/tests/summary.bats
+++ b/tests/summary.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/summary.sh.
+#
+# Each test runs the script with a temp GITHUB_STEP_SUMMARY file and the
+# minimum required env, then asserts on the captured markdown content.
+
+setup() {
+  PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  WORKDIR="$(mktemp -d)"
+  GITHUB_STEP_SUMMARY="$WORKDIR/summary.md"
+  : > "$GITHUB_STEP_SUMMARY"
+  export GITHUB_STEP_SUMMARY
+  export INTEGRATION_ID="int_123"
+  export PRISMATIC_URL="https://example.invalid"
+}
+
+teardown() {
+  rm -rf "$WORKDIR"
+}
+
+@test "summary heading includes PATH_TO_CNI when set" {
+  PATH_TO_CNI="integrations/orders" \
+    "$PROJECT_ROOT/scripts/summary.sh"
+
+  run cat "$GITHUB_STEP_SUMMARY"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"#### \`integrations/orders\`"* ]]
+  [[ "$output" == *"| Source Directory      | integrations/orders |"* ]]
+}
+
+@test "summary heading includes PATH_TO_YML when CNI is unset" {
+  PATH_TO_YML="integrations/orders.yml" \
+    "$PROJECT_ROOT/scripts/summary.sh"
+
+  run cat "$GITHUB_STEP_SUMMARY"
+  [[ "$output" == *"#### \`integrations/orders.yml\`"* ]]
+  [[ "$output" == *"| Source File           | integrations/orders.yml |"* ]]
+}
+
+@test "summary falls back to INTEGRATION_ID when neither path is set" {
+  "$PROJECT_ROOT/scripts/summary.sh"
+
+  run cat "$GITHUB_STEP_SUMMARY"
+  [[ "$output" == *"#### \`int_123\`"* ]]
+}
+
+@test "PATH_TO_CNI takes precedence over PATH_TO_YML" {
+  PATH_TO_CNI="integrations/orders" \
+  PATH_TO_YML="integrations/orders.yml" \
+    "$PROJECT_ROOT/scripts/summary.sh"
+
+  run cat "$GITHUB_STEP_SUMMARY"
+  [[ "$output" == *"#### \`integrations/orders\`"* ]]
+  [[ "$output" == *"| Source Directory      | integrations/orders |"* ]]
+  [[ "$output" != *"| Source File"* ]]
+}


### PR DESCRIPTION
Matrix runs that publish multiple integrations all rendered the same "Integration Published" heading, with only the opaque INTEGRATION_ID distinguishing entries. Add the user-facing source path (PATH_TO_CNI, falling back to PATH_TO_YML, then INTEGRATION_ID) to the heading and as a "Source Directory"/"Source File" row in the table.