### PR TITLE
Support patch releases; drop legacy 2-part version handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
         required: true
         type: choice
         options:
+          - patch
           - minor
           - major
 

--- a/mise.toml
+++ b/mise.toml
@@ -28,11 +28,11 @@ description = "Run all checks (lint + bats)"
 depends = ["lint", "bats"]
 
 [tasks.release]
-description = "Trigger a release workflow run (usage: mise run release -- minor|major)"
+description = "Trigger a release workflow run (usage: mise run release -- patch|minor|major)"
 run = """
 BUMP="{{arg(i=0, name='bump', required=true)}}"
-if [ "$BUMP" != "minor" ] && [ "$BUMP" != "major" ]; then
-  echo "ERROR: Invalid bump type '$BUMP'. Must be minor or major."
+if [ "$BUMP" != "patch" ] && [ "$BUMP" != "minor" ] && [ "$BUMP" != "major" ]; then
+  echo "ERROR: Invalid bump type '$BUMP'. Must be patch, minor, or major."
   exit 1
 fi
 gh workflow run release.yml -f bump="$BUMP"

--- a/scripts/compute-next-version.sh
+++ b/scripts/compute-next-version.sh
@@ -1,39 +1,33 @@
 #!/usr/bin/env bash
 # Compute the next release tag from the latest semver-shaped git tag.
-#
-# Supports both 2-part legacy tags (v2.1, normalized to 2.1.0) and 3-part
-# tags (v2.1.0). Always emits a 3-part tag. Floating major tags (v2) are
-# excluded from the source-of-truth scan.
+# Floating major tags (v2) are excluded from the source-of-truth scan.
 #
 # Inputs (env):
-#   BUMP   "major" or "minor"
+#   BUMP   "major", "minor", or "patch"
 #
 # Outputs (stdout):
 #   The next version tag, e.g. "v2.2.0".
 
 set -euo pipefail
 
-: "${BUMP:?BUMP is required (major or minor)}"
+: "${BUMP:?BUMP is required (major, minor, or patch)}"
 
 case "$BUMP" in
-  major|minor) ;;
+  major|minor|patch) ;;
   *)
-    echo "::error::BUMP must be 'major' or 'minor', got '$BUMP'" >&2
+    echo "::error::BUMP must be 'major', 'minor', or 'patch', got '$BUMP'" >&2
     exit 1
     ;;
 esac
 
-latest=$(git tag --list 'v*.*' --sort=-v:refname \
-  | grep -E '^v[0-9]+\.[0-9]+(\.[0-9]+)?$' \
+latest=$(git tag --list 'v*.*.*' --sort=-v:refname \
+  | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
   | head -1 || true)
 
 if [[ -z "$latest" ]]; then
   base="0.0.0"
 else
   base="${latest#v}"
-  if [[ "$base" =~ ^[0-9]+\.[0-9]+$ ]]; then
-    base="${base}.0"
-  fi
 fi
 
 next=$(semver bump "$BUMP" "$base")

--- a/tests/compute-next-version.bats
+++ b/tests/compute-next-version.bats
@@ -2,11 +2,9 @@
 #
 # Tests for scripts/compute-next-version.sh.
 #
-# These tests exist to document the 2-part → 3-part version migration:
-# the script must read existing legacy tags (v2.1) and produce 3-part
-# successors (v2.2.0). Once all reachable tags are 3-part, this script
-# becomes a thin wrapper over `semver bump` and these tests can be
-# retired.
+# Tests cover the script's own logic — tag filtering, version-sorted
+# selection, and BUMP validation — not the underlying `semver bump`
+# arithmetic.
 
 setup() {
   PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
@@ -23,23 +21,28 @@ teardown() {
   rm -rf "$WORKDIR"
 }
 
-@test "minor bump from 2-part legacy v2.1 produces v2.2.0" {
-  for t in v1.0 v1.1 v2.0 v2.1; do git tag "$t"; done
-  run env BUMP=minor "$PROJECT_ROOT/scripts/compute-next-version.sh"
-  [ "$status" -eq 0 ]
-  [ "$output" = "v2.2.0" ]
-}
-
-@test "major bump from 2-part legacy v2.1 produces v3.0.0" {
-  for t in v1.0 v1.1 v2.0 v2.1; do git tag "$t"; done
-  run env BUMP=major "$PROJECT_ROOT/scripts/compute-next-version.sh"
-  [ "$status" -eq 0 ]
-  [ "$output" = "v3.0.0" ]
-}
-
-@test "version sort picks the highest across mixed 2-part and 3-part tags" {
-  for t in v1.0 v1.5 v1.2 v1.10 v1.10.5; do git tag "$t"; done
+@test "version sort picks the highest tag, not the lex-greatest" {
+  for t in v1.0.0 v1.5.0 v1.2.0 v1.10.0 v1.10.5; do git tag "$t"; done
   run env BUMP=minor "$PROJECT_ROOT/scripts/compute-next-version.sh"
   [ "$status" -eq 0 ]
   [ "$output" = "v1.11.0" ]
+}
+
+@test "floating major tags (e.g. v2) are excluded from the scan" {
+  for t in v1.0.0 v2.0.0 v2; do git tag "$t"; done
+  run env BUMP=patch "$PROJECT_ROOT/scripts/compute-next-version.sh"
+  [ "$status" -eq 0 ]
+  [ "$output" = "v2.0.1" ]
+}
+
+@test "no tags falls back to v0.x.0 baseline" {
+  run env BUMP=minor "$PROJECT_ROOT/scripts/compute-next-version.sh"
+  [ "$status" -eq 0 ]
+  [ "$output" = "v0.1.0" ]
+}
+
+@test "invalid BUMP value is rejected" {
+  run env BUMP=banana "$PROJECT_ROOT/scripts/compute-next-version.sh"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"BUMP must be"* ]]
 }


### PR DESCRIPTION
All reachable tags are now 3-part (v2.2.0 was just minted), so the script no longer needs to normalize legacy v2.1-style tags. Add 'patch' as a valid BUMP value and surface it in the release workflow inputs and the mise release task. Trim the bats suite to cover only behavior that isn't already exercised by 'semver bump' itself: tag filtering, version sort, and BUMP validation.